### PR TITLE
Keep the case of group names retrieved from LDAP

### DIFF
--- a/authenticator/ldap.go
+++ b/authenticator/ldap.go
@@ -238,18 +238,17 @@ func (a *LDAPAuthenticator) getUser(userAsJSON []byte, attributes []*ldap.EntryA
 			if val == "" {
 				continue
 			}
-			val = strings.ToLower(val)
-			if a.PrimaryGroupPrefix != "" && strings.HasPrefix(val, a.PrimaryGroupPrefix) {
+			if a.PrimaryGroupPrefix != "" && strings.HasPrefix(strings.ToLower(val), a.PrimaryGroupPrefix) {
 				groups = append(groups, sdk.GroupMapping{
 					Name: val,
 					Type: sdk.GroupTypePrimary,
 				})
-			} else if a.SecondaryGroupPrefix != "" && strings.HasPrefix(val, a.SecondaryGroupPrefix) {
+			} else if a.SecondaryGroupPrefix != "" && strings.HasPrefix(strings.ToLower(val), a.SecondaryGroupPrefix) {
 				groups = append(groups, sdk.GroupMapping{
 					Name: val,
 					Type: sdk.GroupTypeSecondary,
 				})
-			} else if a.MembershipGroupPrefix != "" && strings.HasPrefix(val, a.MembershipGroupPrefix) {
+			} else if a.MembershipGroupPrefix != "" && strings.HasPrefix(strings.ToLower(val), a.MembershipGroupPrefix) {
 				groups = append(groups, sdk.GroupMapping{
 					Name: val,
 					Type: sdk.GroupTypeMembership,

--- a/authenticator/utils.go
+++ b/authenticator/utils.go
@@ -83,7 +83,7 @@ func getCNFromDN(dn string) string {
 	if len(parts) > 0 {
 		cn := strings.ToLower(parts[0])
 		if strings.HasPrefix(cn, "cn=") || strings.HasPrefix(cn, "ou=") {
-			return strings.TrimSpace(cn[3:])
+			return strings.TrimSpace(parts[0][3:])
 		}
 	}
 	return ""


### PR DESCRIPTION
Currently there's no way an LDAP group can match an SFTPGo group if the SFTPGo group's name contains uppercase letters, resulting in database NULL value error on the SFTPGo side when creating an LDAP user.

Although LDAP is case insensitive, SFTPGo is case sensitive. So I think it's better to keep the case of group names retrieved from LDAP.