### PR TITLE
Fix: return non-empty value if trimming is not required

### DIFF
--- a/authenticator/ldap_test.go
+++ b/authenticator/ldap_test.go
@@ -352,6 +352,8 @@ func TestGetCNFromDN(t *testing.T) {
 	res = getCNFromDN("cn=test")
 	assert.Equal(t, "test", res)
 	res = getCNFromDN("test")
+	assert.Equal(t, "test", res)
+	res = getCNFromDN("")
 	assert.Empty(t, res)
 	res = getCNFromDN("cn=admin ,ou=users,dc=mylab,dc=local")
 	assert.Equal(t, "admin", res)

--- a/authenticator/utils.go
+++ b/authenticator/utils.go
@@ -85,6 +85,7 @@ func getCNFromDN(dn string) string {
 		if strings.HasPrefix(cn, "cn=") || strings.HasPrefix(cn, "ou=") {
 			return strings.TrimSpace(cn[3:])
 		}
+		return cn
 	}
 	return ""
 }


### PR DESCRIPTION
Currently function returns an empty string if "cn=" or "ou=" trimming is not required.
This one-line PR fixes this behavior.

# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---